### PR TITLE
feat: add cover photo upload to property form and details

### DIFF
--- a/src/features/property/components/PropertyDetails.tsx
+++ b/src/features/property/components/PropertyDetails.tsx
@@ -1,4 +1,4 @@
-import { Stack, Typography } from '@mui/material';
+import { Box, Stack, Typography } from '@mui/material';
 import type { Property } from '../types/property.types';
 
 interface Props {
@@ -6,12 +6,19 @@ interface Props {
 }
 
 const PropertyDetails = ({ property }: Props) => {
-  const { owner, address, surface } = property;
+  const { owner, address, surface, image } = property;
   const ownerName = `${owner.firstName} ${owner.lastName}`;
   const addressLine = `${address.number ? address.number + ' ' : ''}${address.street}, ${address.postCode} ${address.city}`;
 
   return (
     <Stack gap={1}>
+      {image && (
+        <Box
+          component="img"
+          src={image}
+          sx={{ width: '100%', maxHeight: 300, objectFit: 'cover', borderRadius: 1, mb: 1 }}
+        />
+      )}
       <Typography variant="body1">
         <strong>Propriétaire :</strong> {ownerName}
       </Typography>

--- a/src/features/property/components/PropertyForm.tsx
+++ b/src/features/property/components/PropertyForm.tsx
@@ -1,5 +1,5 @@
 import { useState, type ChangeEvent } from 'react';
-import { Button, FormGroup, Stack, Typography, Alert } from '@mui/material';
+import { Box, Button, FormGroup, Stack, Typography, Alert } from '@mui/material';
 import { createPropertySchema } from '../types/property.types';
 import type { CreatePropertyData, Property } from '../types/property.types';
 import type { Address } from '../../../types/address.types';
@@ -31,6 +31,14 @@ const PropertyForm = ({ initialValues, onSubmit, onCancel, isLoading, submitLabe
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
     setValues((prev) => ({ ...prev, [name]: name === 'surface' ? Number(value) : value }));
+  };
+
+  const handleImageChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => setValues((prev) => ({ ...prev, image: reader.result as string }));
+    reader.readAsDataURL(file);
   };
 
   const handleAddressChange = (address: Address) => setValues((prev) => ({ ...prev, address }));
@@ -73,6 +81,34 @@ const PropertyForm = ({ initialValues, onSubmit, onCancel, isLoading, submitLabe
 
         <AddressForm address={values.address} onChange={handleAddressChange} />
         <OwnerForm owner={values.owner} onChange={handleOwnerChange} />
+
+        <Box>
+          <Typography variant="subtitle1" color="text.secondary" mb={1}>
+            Photo de couverture
+          </Typography>
+          {values.image && (
+            <Box
+              component="img"
+              src={values.image}
+              sx={{ width: '100%', maxHeight: 200, objectFit: 'cover', borderRadius: 1, mb: 1 }}
+            />
+          )}
+          <Stack direction="row" gap={1}>
+            <Button variant="outlined" size="small" component="label">
+              {values.image ? 'Changer la photo' : 'Ajouter une photo'}
+              <input type="file" accept="image/*" hidden onChange={handleImageChange} />
+            </Button>
+            {values.image && (
+              <Button
+                size="small"
+                color="error"
+                onClick={() => setValues((prev) => ({ ...prev, image: '' }))}
+              >
+                Supprimer
+              </Button>
+            )}
+          </Stack>
+        </Box>
       </Stack>
 
       <Stack direction="row" gap={2} mt={3}>


### PR DESCRIPTION
Add a file input with preview in PropertyForm to upload a cover image (stored as base64 data URL). Display the image in PropertyDetails page.

https://claude.ai/code/session_01FKg6pPEjuztr8F4rAQyf65